### PR TITLE
Memperbaiki penempatan posisi log file

### DIFF
--- a/apps/processor/Dockerfile
+++ b/apps/processor/Dockerfile
@@ -64,4 +64,16 @@ COPY --from=builder --chown=processor:nodejs /vote-processor /vote-processor
 
 WORKDIR /vote-processor
 
-CMD ["node", "node_modules/@sora-vp/processor/dist/index.js"]
+COPY <<EOF /vote-processor/index.js
+import path from "path";
+import { fileURLToPath } from "url";
+
+import { consumeMessagesFromQueue } from "@sora-vp/processor";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+void consumeMessagesFromQueue(__dirname);
+EOF
+
+CMD ["node", "index.js"]

--- a/apps/processor/eslint.config.js
+++ b/apps/processor/eslint.config.js
@@ -3,7 +3,7 @@ import baseConfig from "@sora-vp/eslint-config/base";
 /** @type {import('typescript-eslint').Config} */
 export default [
   {
-    ignores: [".dist/**", "tsup.config.ts"],
+    ignores: ["dist/**", "index.ts", "tsup.config.ts"],
   },
   ...baseConfig,
 ];

--- a/apps/processor/index.ts
+++ b/apps/processor/index.ts
@@ -1,0 +1,9 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+import { consumeMessagesFromQueue } from "./src/index";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+void consumeMessagesFromQueue(__dirname);

--- a/apps/processor/package.json
+++ b/apps/processor/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf .turbo node_modules",
-    "dev": "yarn with-env tsx watch src/index.ts",
+    "dev": "yarn with-env tsx watch ./index.ts",
     "lint": "eslint",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "typecheck": "tsc --noEmit",

--- a/apps/processor/src/index.ts
+++ b/apps/processor/src/index.ts
@@ -10,7 +10,7 @@ import { validateId } from "@sora-vp/id-generator";
 import { api } from "./api";
 import { db, schema } from "./db";
 import { env } from "./env";
-import { logger } from "./logger";
+import { initLogger } from "./logger";
 import { canVoteNow } from "./utils";
 
 const inputValidator = z.object({
@@ -18,7 +18,9 @@ const inputValidator = z.object({
   qrId: z.string().refine(validateId),
 });
 
-const consumeMessagesFromQueue = async () => {
+export const consumeMessagesFromQueue = async (loggerDirectory: string) => {
+  const logger = initLogger(loggerDirectory);
+
   try {
     logger.debug(`[MQ] MQ AMQP: ${env.AMQP_URL}`);
     logger.debug(`[TRPC] TRPC URL: ${env.PROCESSOR_API_URL}`);
@@ -226,5 +228,3 @@ const consumeMessagesFromQueue = async () => {
     logger.error(error);
   }
 };
-
-void consumeMessagesFromQueue();

--- a/apps/processor/src/logger.ts
+++ b/apps/processor/src/logger.ts
@@ -1,29 +1,26 @@
 import path from "path";
-import { fileURLToPath } from "url";
 import pino from "pino";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-export const logger = pino({
-  transport: {
-    targets: [
-      {
-        target: "pino-pretty",
-        level: "debug",
-        options: {
-          colorize: true,
-          ignore: "pid,hostname",
-          translateTime: "SYS:standard",
+export const initLogger = (destinationDirectoryPath: string) =>
+  pino({
+    transport: {
+      targets: [
+        {
+          target: "pino-pretty",
+          level: "debug",
+          options: {
+            colorize: true,
+            ignore: "pid,hostname",
+            translateTime: "SYS:standard",
+          },
         },
-      },
-      {
-        target: "pino/file",
-        level: "debug",
-        options: {
-          destination: path.join(__dirname, "..", "processor.log"),
+        {
+          target: "pino/file",
+          level: "debug",
+          options: {
+            destination: path.join(destinationDirectoryPath, "processor.log"),
+          },
         },
-      },
-    ],
-  },
-});
+      ],
+    },
+  });


### PR DESCRIPTION
Supaya kompatibel dengan konfigurasi docker. Sebenernya bisa aja nyomot log filenya langsung dari `/node_module/.....` tapi terlalu dalem, mending langsung di pindah ke atas aja biar barengan, sama-sama di `/vote-processor`